### PR TITLE
Update gen scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ linkchecker-out.csv
 *.bak
 *.syso
 *.log
+documentation/doxygen/src/history.txt

--- a/documentation/doxygen/compiler.dxy.in
+++ b/documentation/doxygen/compiler.dxy.in
@@ -918,6 +918,7 @@ WARN_LOGFILE           =
 
 INPUT                  = ./src/mainpage.md                 \
                          ./src/history.md                  \
+                         ./src/history.txt                 \
                          ./src/rt_io.md                    \
                          ./src/rt_os.md                    \
                          ../../example/README.md           \

--- a/documentation/doxygen/gen_doc.sh
+++ b/documentation/doxygen/gen_doc.sh
@@ -13,7 +13,7 @@ set -o pipefail
 # Set version of gen pack library
 # For available versions see https://github.com/Open-CMSIS-Pack/gen-pack/tags.
 # Use the tag name without the prefix "v", e.g., 0.7.0
-REQUIRED_GEN_PACK_LIB="0.9.0"
+REQUIRED_GEN_PACK_LIB="0.9.1"
 
 DIRNAME=$(dirname "$(readlink -f "$0")")
 GENDIR=../html
@@ -82,7 +82,7 @@ year=$(date -u +'%Y')
 
 sed -e "s/{projectNumber}/${projectNumber}/" compiler.dxy.in > compiler.dxy
 
-#git_changelog -f html -p "pack/" > src/history.txt
+git_changelog -f html -p "v" > src/history.txt
 
 echo "\"${UTILITY_DOXYGEN}\" compiler.dxy"
 "${UTILITY_DOXYGEN}" compiler.dxy

--- a/documentation/doxygen/linkchecker.rc
+++ b/documentation/doxygen/linkchecker.rc
@@ -6,4 +6,7 @@ ignoreerrors=
     mag_seld.svg
     ../tab_a.png
     ../tab_ad.png
-    
+
+[filtering]
+ignorewarnings=
+    http-redirected

--- a/documentation/doxygen/src/history.md
+++ b/documentation/doxygen/src/history.md
@@ -3,17 +3,3 @@
 CMSIS-Compiler version is offically updated upon releases of the [CMSIS-Compiler pack](https://www.keil.arm.com/packs/cmsis-compiler-arm/versions/).
 
 The table below provides information about the changes delivered with specific versions of CMSIS-Compiler.
-
-<table class="cmtable" summary="Revision History">
-    <tr>
-      <th>Version</th>
-      <th>Description</th>
-    </tr>
-    <tr>
-      <td>1.0.0</td>
-      <td>
-       Initial release replacing I/O Retarget from Keil.ARM-Compiler pack.
-       </td>
-    </tr>
-
-</table>

--- a/gen_pack.sh
+++ b/gen_pack.sh
@@ -9,7 +9,7 @@ set -o pipefail
 # Set version of gen pack library
 # For available versions see https://github.com/Open-CMSIS-Pack/gen-pack/tags.
 # Use the tag name without the prefix "v", e.g., 0.7.0
-REQUIRED_GEN_PACK_LIB="0.9.0"
+REQUIRED_GEN_PACK_LIB="0.9.1"
 
 # Set default command line arguments
 DEFAULT_ARGS=(-c "v")
@@ -110,9 +110,9 @@ function postprocess() {
 # Set GEN_PACK_LIB_PATH to use a specific gen-pack library root
 # ... instead of bootstrap based on REQUIRED_GEN_PACK_LIB
 if [[ -f "${GEN_PACK_LIB_PATH}/gen-pack" ]]; then
-  . "${GEN_PACK_LIB}/gen-pack"
+  . "${GEN_PACK_LIB_PATH}/gen-pack"
 else
-  . <(curl -sL "https://raw.githubusercontent.com/Open-CMSIS-Pack/gen-pack/main/bootstrap")
+    . <(curl -sL "https://raw.githubusercontent.com/Open-CMSIS-Pack/gen-pack/main/bootstrap")
 fi
 
 gen_pack "${DEFAULT_ARGS[@]}" "$@"


### PR DESCRIPTION
 - Bump gen-pack version to 0.9.1
   This fixes processing dev-drop tags.
 - Ignore linkchecker http-redirect warnings
 - Generate documentation version history